### PR TITLE
Remove "Select *" in favor of enumerating fields

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -466,6 +466,18 @@ Schema.prototype.secondaryKeys = function () {
 Schema.prototype.fields = function () {
   return this._columnKeys;
 };
+
+Schema.prototype.fieldString = function (fieldList) {
+  if (!Array.isArray(fieldList) || !fieldList.length) {
+    fieldList = this.fields();
+  }
+  return fieldList
+    .map(function (fieldName) {
+      return fieldName && ('"' + fieldName + '"');
+    })
+    .join(', ');
+}
+
 //
 // Return all fields, we are going to default to dealing with this as camelCase
 //

--- a/lib/statement-builder/statements/find.js
+++ b/lib/statement-builder/statements/find.js
@@ -49,7 +49,7 @@ FindStatement.prototype.build = function (options) {
   var fields = options.fields;
   var limit = options.limit;
   var type = options.type;
-  var fieldsCql = '*';
+
   //
   // We default to the table set on conditionals if we are doing a find on
   // a lookup table. We establish this when we create conditions so it kind of
@@ -57,10 +57,11 @@ FindStatement.prototype.build = function (options) {
   //
   var table = conditionals.table || this.table;
 
+  var fieldsCql;
   if (type === 'count') {
     fieldsCql = 'COUNT(*)';
-  } else if (fields && fields.length) {
-    fieldsCql = fields.join(', ');
+  } else {
+    fieldsCql = this.schema.fieldString(fields);
   }
 
   this.cql = util.format('SELECT %s FROM %s', fieldsCql, table);

--- a/test/unit/schema.tests.js
+++ b/test/unit/schema.tests.js
@@ -74,4 +74,17 @@ describe('Schema (unit)', function () {
     assume(valid).eql(schema.fixKeys(entity));
     debug(valid);
   });
+
+  it('#fieldString() should return a list of all fields suitable for CQL ' +
+     'consumption if no arguments are given', function () {
+    schema = new Schema('artist', schemas.artist);
+    assume(schema.fieldString()).eql(
+      '"artist_id", "name", "create_date", "update_date", "members", "related_artists", "traits", "metadata"');
+  });
+
+  it('#fieldString() should return a list of fields suitable for CQL ' +
+     'consumption when a list of fields is given', function () {
+    schema = new Schema('artist', schemas.artist);
+    assume(schema.fieldString(['artist_id', 'name'])).eql('"artist_id", "name"');
+  });
 });

--- a/test/unit/statement-builder.tests.js
+++ b/test/unit/statement-builder.tests.js
@@ -21,12 +21,21 @@ var artistEntity = require(path.join(fixturesDir, 'artist-entity'));
 describe('StatementBuilder', function () {
   var schema = new Schema('artist', schemas.artist);
   var builder = new StatementBuilder(schema);
+  var fieldList = schema.fieldString();
 
   describe('FindStatement', function () {
     it('should return an find ALL statement if given an empty object or no options', function () {
       var statement = builder.find({ type: 'find' }, {});
 
-      assume(statement.cql).to.equal('SELECT * FROM artist');
+      assume(statement.cql).to.equal('SELECT ' + fieldList + ' FROM artist');
+    });
+
+    it('should return an find statement with a field list if fields in options', function () {
+      var statement = builder.find({
+        type: 'find',
+        fields: ['artist_id', 'name']
+      }, {});
+      assume(statement.cql).to.equal('SELECT "artist_id", "name" FROM artist');
     });
 
     it('should return a find statement with a limit if specified in options', function () {
@@ -35,7 +44,7 @@ describe('StatementBuilder', function () {
         limit: 2
       }, {});
 
-      assume(statement.cql).to.equal('SELECT * FROM artist LIMIT 2');
+      assume(statement.cql).to.equal('SELECT ' + fieldList + ' FROM artist LIMIT 2');
     });
 
     it('should return an error when passed conditions that get filtered (non primary keys)', function () {


### PR DESCRIPTION
This will facilitate easier schema changes.

In the event of adding a column:
 - Update Cassandra schema first
 - Then update DataStar schema and roll out code

In the event of removing a column:
 - Update DataStar schema and deploy code
 - Update Cassandra schema