### PR TITLE
Recursive null

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -632,7 +632,7 @@ Schema.prototype.nullToValue = function (meta, value) {
       return memo;
     }, {});
   }
-  if (type === 'set' || type === 'list') {
+  if (type === 'set') {
     // Sets are an odd edge case here, it can be an array or an object who's
     // values are sit in an add and/or remove property. This means we need to
     // a bit more work updating this data structure.
@@ -644,6 +644,19 @@ Schema.prototype.nullToValue = function (meta, value) {
       });
 
       return value;
+    } else {
+      return value.map(function map(value) {
+        return self.nullToValue({ type: meta.setType }, value);
+      });
+    }
+  }
+  if (type === 'list') {
+    if (this.type(value) === 'object') {
+      ['prepend', 'append', 'remove'].forEach(function each(method) {
+          if (method in value) value[method] = value[method].map(function map(value) {
+          return self.nullToValue({ type: meta.setType }, value);
+        });
+      });
     } else {
       return value.map(function map(value) {
         return self.nullToValue({ type: meta.setType }, value);
@@ -687,7 +700,7 @@ Schema.prototype.valueToNull = function (value) {
     return null;
   }
   if (type === 'array') {
-    for (var i = 0, l = value.length; i < l; i++) {
+    for (var i = 0, i < value.length; i++) {
       value[i] = this.valueToNull(value[i]);
     }
 
@@ -696,7 +709,7 @@ Schema.prototype.valueToNull = function (value) {
   if (type === 'object') {
     var keys = Object.keys(value);
 
-    for (var i = 0, l = keys.length; i < l; i++) {
+    for (var i = 0, i < keys.length; i++) {
       value[keys[i]] = this.valueToNull(value[keys[i]]);
     }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -653,7 +653,7 @@ Schema.prototype.nullToValue = function (meta, value) {
   if (type === 'list') {
     if (this.type(value) === 'object') {
       ['prepend', 'append', 'remove'].forEach(function each(method) {
-          if (method in value) value[method] = value[method].map(function map(value) {
+        if (method in value) value[method] = value[method].map(function map(value) {
           return self.nullToValue({ type: meta.listType }, value);
         });
       });
@@ -707,7 +707,7 @@ Schema.prototype.valueToNull = function (value) {
     return null;
   }
   if (type === 'array') {
-    for (var i = 0; i < value.length; i++) {
+    for (let i = 0; i < value.length; i++) {
       value[i] = this.valueToNull(value[i]);
     }
 
@@ -716,7 +716,7 @@ Schema.prototype.valueToNull = function (value) {
   if (type === 'object') {
     var keys = Object.keys(value);
 
-    for (var i = 0; i < keys.length; i++) {
+    for (let i = 0; i < keys.length; i++) {
       value[keys[i]] = this.valueToNull(value[keys[i]]);
     }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -654,9 +654,16 @@ Schema.prototype.nullToValue = function (meta, value) {
     if (this.type(value) === 'object') {
       ['prepend', 'append', 'remove'].forEach(function each(method) {
           if (method in value) value[method] = value[method].map(function map(value) {
-          return self.nullToValue({ type: meta.setType }, value);
+          return self.nullToValue({ type: meta.listType }, value);
         });
       });
+
+      if (value.index && this.type(value.index) === 'object') {
+        value.index = Object.keys(value.index).reduce(function (acc, idx) {
+          acc[idx] = self.nullToValue({ type: meta.listType }, value.index[idx]);
+          return acc;
+        }, {});
+      }
     } else {
       return value.map(function map(value) {
         return self.nullToValue({ type: meta.setType }, value);
@@ -700,7 +707,7 @@ Schema.prototype.valueToNull = function (value) {
     return null;
   }
   if (type === 'array') {
-    for (var i = 0, i < value.length; i++) {
+    for (var i = 0; i < value.length; i++) {
       value[i] = this.valueToNull(value[i]);
     }
 
@@ -709,7 +716,7 @@ Schema.prototype.valueToNull = function (value) {
   if (type === 'object') {
     var keys = Object.keys(value);
 
-    for (var i = 0, i < keys.length; i++) {
+    for (var i = 0; i < keys.length; i++) {
       value[keys[i]] = this.valueToNull(value[keys[i]]);
     }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -653,9 +653,29 @@ Schema.prototype.valueToNull = function (value) {
   if (value === '00000000-0000-0000-0000-000000000000') {
     return null;
   }
-  if (this.type(value) === 'date' && value.getTime() === 0) {
+
+  var type = this.type(value);
+
+  if (type === 'date' && value.getTime() === 0) {
     return null;
   }
+  if (type === 'array') {
+    for (var i = 0, l = value.length; i < l; i++) {
+      value[i] = this.valueToNull(value[i]);
+    }
+
+    return value;
+  }
+  if (type === 'object') {
+    var keys = Object.keys(value);
+
+    for (var i = 0, l = keys.length; i < l; i++) {
+      value[keys[i]] = this.valueToNull(value[keys[i]]);
+    }
+
+    return value;
+  }
+
   return value;
 };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -585,10 +585,10 @@ Schema.prototype.deNull = function (entity) {
       break;
     }
 
-    entity[key] = this.nullToValue(meta.type, value);
+    entity[key] = this.nullToValue(meta, value);
   }
 
-  return error ? error : entity;
+  return error || entity;
 };
 
 Schema.prototype.hasAllRequiredKeys = function (entity, previous) {
@@ -607,7 +607,10 @@ function isBadUuid(value) {
 // Adjust detected values that are `null` and map them to a `null-like` value.
 // TODO: Should we iterate through maps and sets and adjust accordingly as well?
 //
-Schema.prototype.nullToValue = function (type, value) {
+Schema.prototype.nullToValue = function (meta, value) {
+  var type = meta.type,
+      self = this;
+
   if ((type === 'text' || type === 'ascii') && value === null) {
     // null text values will create tombstones in Cassandra
     // We will write a null string instead.
@@ -622,6 +625,30 @@ Schema.prototype.nullToValue = function (type, value) {
     // null timestamp values will create tombstones in Cassandra
     // We will write a zero time instead.
     return new Date(0);
+  }
+  if (type === 'map') {
+    return Object.keys(value).reduce(function reduce(memo, key) {
+      memo[key] = self.nullToValue({ type: meta.mapType[1] }, value[key]);
+      return memo;
+    }, {});
+  }
+  if (type === 'set' || type === 'list') {
+    // Sets are an odd edge case here, it can be an array or an object who's
+    // values are sit in an add and/or remove property. This means we need to
+    // a bit more work updating this data structure.
+    if (this.type(value) === 'object') {
+      ['add', 'remove'].forEach(function each(method) {
+        if (method in value) value[method] = value[method].map(function map(value) {
+          return self.nullToValue({ type: meta.setType }, value);
+        });
+      });
+
+      return value;
+    } else {
+      return value.map(function map(value) {
+        return self.nullToValue({ type: meta.setType }, value);
+      });
+    }
   }
 
   return value;

--- a/test/fixtures/schemas.js
+++ b/test/fixtures/schemas.js
@@ -16,7 +16,7 @@ module.exports = {
     members: cql.set(cql.text()),
     related_artists: cql.set(cql.uuid()).allow(null),
     traits: cql.set(cql.text()),
-    metadata: cql.map(cql.text(), cql.text().allow(null))
+    metadata: cql.map(cql.text(), cql.text())
   }).partitionKey('artist_id')
     .rename('id', 'artist_id', { ignoreUndefined: true }),
   album: joi.object({

--- a/test/fixtures/schemas.js
+++ b/test/fixtures/schemas.js
@@ -16,7 +16,7 @@ module.exports = {
     members: cql.set(cql.text()),
     related_artists: cql.set(cql.uuid()).allow(null),
     traits: cql.set(cql.text()),
-    metadata: cql.map(cql.text(), cql.text())
+    metadata: cql.map(cql.text(), cql.text().allow(null))
   }).partitionKey('artist_id')
     .rename('id', 'artist_id', { ignoreUndefined: true }),
   album: joi.object({

--- a/test/integration/model.tests.js
+++ b/test/integration/model.tests.js
@@ -7,6 +7,7 @@ var assume            = require('assume'),
     async             = require('async'),
     clone             = require('clone'),
     schemas           = require('../fixtures/schemas'),
+    Datastar          = require('../..'),
     datastarTestTools = require('datastar-test-tools');
 
 var helpers = datastarTestTools.helpers;
@@ -19,7 +20,7 @@ describe('Model', function () {
   before(function (done) {
     helpers.load(function (err, data) {
       assume(err).to.equal(null);
-      datastar = helpers.connectDatastar({ config: data.cassandra }, null, done);
+      datastar = helpers.connectDatastar({ config: data.cassandra }, Datastar, done);
       /* cassandra = new driver.Client({
        contactPoints: data.cassandra.hosts,
        keyspace: data.cassandra.keyspace
@@ -139,7 +140,6 @@ describe('Model', function () {
       // SELECT [fields] FROM [table] WHERE [conditions.query[0]] AND [conditionals.query[1]] FROM [schema.name]
       var options = {
         type: 'all',
-        fields: ['*'],
         conditions: {
           artistId: '00000000-0000-0000-0000-000000000002'
         }
@@ -171,7 +171,6 @@ describe('Model', function () {
 
       var findOptions = {
         type: 'all',
-        fields: ['*'],
         conditions: {
           artistId: id
         }

--- a/test/integration/model.tests.js
+++ b/test/integration/model.tests.js
@@ -113,7 +113,20 @@ describe('Model', function () {
               assume(result.metadata.what).to.equal(update.metadata.what);
               assume(result.relatedArtists.sort()).to.deep.equal(update.relatedArtists.sort());
 
-              Artist.remove(entity, done);
+              //
+              // By passing a null we set the map value to null
+              //
+              Artist.update({
+                id: entity.id,
+                metadata: {
+                  hello: null
+                }
+              }, function (err, result) {
+                assume(err).to.be.falsey();
+                assume(result.metadata.hello).to.be.falsey();
+
+                Artst.remove(entity, done);
+              });
             });
           });
         });

--- a/test/integration/model.tests.js
+++ b/test/integration/model.tests.js
@@ -121,11 +121,13 @@ describe('Model', function () {
                 metadata: {
                   hello: null
                 }
-              }, function (err, result) {
-                assume(err).to.be.falsey();
-                assume(result.metadata.hello).to.be.falsey();
+              }, function (err) {
+                assume(err).is.falsey();
+                find(Artist, entity.id, function (_, result) {
+                  assume(result.metadata.hello).is.falsey();
 
-                Artst.remove(entity, done);
+                  Artst.remove(entity, done);
+                });
               });
             });
           });

--- a/test/integration/model.tests.js
+++ b/test/integration/model.tests.js
@@ -126,7 +126,7 @@ describe('Model', function () {
                 find(Artist, entity.id, function (_, result) {
                   assume(result.metadata.hello).is.falsey();
 
-                  Artst.remove(entity, done);
+                  Artist.remove(entity, done);
                 });
               });
             });


### PR DESCRIPTION
Properly null/denull within maps to prevent tombstones and to handle us passing `null` into update since the latest cassandra driver does not handle this.