### PR TITLE
Fixes getting param values

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -880,7 +880,11 @@ Schema.prototype.parseConditions = function (conditions) {
     // Whats returned by this._getParams is actually the proper value for the
     // query
     //
-    conditionals.params.push(this.valueOf(field, this._getParams(field, value)));
+    var params = this._getParams(field, value);
+    params = params instanceof Array ? params : [params];
+    params.forEach(function (param) {
+      conditionals.params.push(this.valueOf(field, param));
+    }, this);
 
   }, this);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -881,7 +881,7 @@ Schema.prototype.parseConditions = function (conditions) {
     // query
     //
     var params = this._getParams(field, value);
-    params = params instanceof Array ? params : [params];
+    params = Array.isArray(params) ? params : [params];
     params.forEach(function (param) {
       conditionals.params.push(this.valueOf(field, param));
     }, this);

--- a/test/unit/statement-builder.tests.js
+++ b/test/unit/statement-builder.tests.js
@@ -63,6 +63,20 @@ describe('StatementBuilder', function () {
 
       assume(statement).is.an.Error;
     });
+
+    it('should return a find statement with query params', function () {
+      var statement = builder.find({
+        type: 'find',
+        conditions: {
+          artistId: { lte: '2345', gt: '1234' }
+        }
+      });
+
+      assume(statement.cql).to.equal('SELECT ' + fieldList + ' FROM artist WHERE artist_id <= ? AND artist_id > ?');
+      assume(statement.params.length).to.equal(2);
+      assume(statement.params[0].value).to.equal('2345');
+      assume(statement.params[1].value).to.equal('1234');
+    });
   });
 
   describe('Lookup Tables', function () {


### PR DESCRIPTION
Currently, queries using operator like `{ lte, lt, gte, gt}` are not working because of the way we're collecting value for each param. This PR fixes that. 