### PR TITLE
Add error event listener to model EventEmitter to capture Model action error responses

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -61,6 +61,14 @@ Model.init = function init(options) {
   });
 
   //
+  // Without an event listener for `error` events, errors result in a process exit.
+  // https://nodejs.org/docs/latest-v10.x/api/events.html#events_error_events
+  //
+  this.emitter.on('error', (err) => {
+    console.error(`Model ${options.name}`, err);
+  });
+
+  //
   // Remark: We might not need to do the following, but we should look into the
   // dangers of what happens when a primary/secondary key is modified
   // Before we update we need to check a few things.


### PR DESCRIPTION
Receiving an error response from a Model action is currently not caught by the Model’s event emitter, which instead causes a `process.exit(1)` to be triggered. Adding an `error` event listener as part of the Model allows these errors to be captured without service termination.

I’ve only implemented a basic `console.error` as part of the listener. I did try to implement an `errorCallback` that consumers can provide via the `options` parameter in [lib/index.js:92](https://github.com/godaddy/datastar/blob/master/lib/index.js#L92) but this was breaking existing functionality when arguments are manipulated.