### PR TITLE
Upgrade vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "async": "^3.2.4",
         "clone": "^1.0.4",
-        "joi-of-cql": "^2.0.2",
+        "joi-of-cql": "^2.0.4",
         "lodash.pick": "^4.0.1",
         "object-assign": "^4.0.1",
         "priam": "^4.0.0",
@@ -1691,7 +1691,7 @@
     "node_modules/isemail": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+      "integrity": "sha512-LPjFxaTatluwGAJlGe4FtRdzg0a9KlXrahHoHAR4HwRNf90Ttwi6sOQ9zj+EoCPmk9yyK+WFUqkm0imUo8UJbw==",
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1818,15 +1818,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/items": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
+      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg==",
+      "deprecated": "This module has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version of hapi to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial)."
+    },
     "node_modules/joi": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-8.4.2.tgz",
-      "integrity": "sha1-vXd0ZY/pkFjYmU7R1LmWJITruFk=",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
       "dependencies": {
         "hoek": "4.x.x",
         "isemail": "2.x.x",
-        "moment": "2.x.x",
+        "items": "2.x.x",
         "topo": "2.x.x"
       },
       "engines": {
@@ -1834,11 +1840,11 @@
       }
     },
     "node_modules/joi-of-cql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/joi-of-cql/-/joi-of-cql-2.0.2.tgz",
-      "integrity": "sha512-bdGbQwsYGMxXFsnNgtpmhu+J6804+iOFm0VM37kPpB7Yflp42UsokAToxC7cwVcDYKK+XrVyynrwgxnggT+Mkw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/joi-of-cql/-/joi-of-cql-2.0.4.tgz",
+      "integrity": "sha512-/Ve2Oa4qU/kjzFKOyWwq/7THHy2DDGmt2eqLacLWk3jq6iHLPqezb8+BQOjy/jGS5okcQq4DIoFjR1rubMLmBw==",
       "dependencies": {
-        "joi": "^8.4.2",
+        "joi": "^10.6.0",
         "uuid": "^3.3.3"
       }
     },
@@ -2492,14 +2498,6 @@
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3399,7 +3397,7 @@
     "node_modules/topo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "integrity": "sha512-QMfJ9TC5lKcmLZImOZ/BTSWJeVbay7XK2nlzvFALW3BA5OkvBnbs0poku4EsRpDMndDVnM58EU/8D3ZcoVehWg==",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
       "dependencies": {
         "hoek": "4.x.x"
@@ -5000,7 +4998,7 @@
     "isemail": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+      "integrity": "sha512-LPjFxaTatluwGAJlGe4FtRdzg0a9KlXrahHoHAR4HwRNf90Ttwi6sOQ9zj+EoCPmk9yyK+WFUqkm0imUo8UJbw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5103,23 +5101,28 @@
         "html-escaper": "^2.0.0"
       }
     },
+    "items": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
+      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+    },
     "joi": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-8.4.2.tgz",
-      "integrity": "sha1-vXd0ZY/pkFjYmU7R1LmWJITruFk=",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
       "requires": {
         "hoek": "4.x.x",
         "isemail": "2.x.x",
-        "moment": "2.x.x",
+        "items": "2.x.x",
         "topo": "2.x.x"
       }
     },
     "joi-of-cql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/joi-of-cql/-/joi-of-cql-2.0.2.tgz",
-      "integrity": "sha512-bdGbQwsYGMxXFsnNgtpmhu+J6804+iOFm0VM37kPpB7Yflp42UsokAToxC7cwVcDYKK+XrVyynrwgxnggT+Mkw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/joi-of-cql/-/joi-of-cql-2.0.4.tgz",
+      "integrity": "sha512-/Ve2Oa4qU/kjzFKOyWwq/7THHy2DDGmt2eqLacLWk3jq6iHLPqezb8+BQOjy/jGS5okcQq4DIoFjR1rubMLmBw==",
       "requires": {
-        "joi": "^8.4.2",
+        "joi": "^10.6.0",
         "uuid": "^3.3.3"
       },
       "dependencies": {
@@ -5618,11 +5621,6 @@
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.3",
@@ -6334,7 +6332,7 @@
     "topo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "integrity": "sha512-QMfJ9TC5lKcmLZImOZ/BTSWJeVbay7XK2nlzvFALW3BA5OkvBnbs0poku4EsRpDMndDVnM58EU/8D3ZcoVehWg==",
       "requires": {
         "hoek": "4.x.x"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1747,9 +1747,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2131,15 +2131,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/merge-descriptors": {
@@ -3097,9 +3088,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -3552,9 +3543,9 @@
       "dev": true
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5042,9 +5033,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -5349,12 +5340,6 @@
           "version": "4.0.1",
           "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
           "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
@@ -6079,9 +6064,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true
     },
     "serialize-javascript": {
@@ -6463,9 +6448,9 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "workerpool": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "async": "^3.2.4",
     "clone": "^1.0.4",
-    "joi-of-cql": "^2.0.2",
+    "joi-of-cql": "^2.0.4",
     "lodash.pick": "^4.0.1",
     "object-assign": "^4.0.1",
     "priam": "^4.0.0",


### PR DESCRIPTION
- `joi-of-cql` is [updated to take advantage of this change](https://github.com/godaddy/joi-of-cql/pull/22) 
- `semver` and `word-wrap` were both updated via `npm audit fix` so are bundled in 1 commit rather than 2, both of these dependencies are only used in in `devDependencies` so does not affect runtime

```
connor.burton@LM-C02FV8NHMD6R datastar % npm ls semver
datastar@4.0.3 /Users/connor.burton/dev/datastar
└─┬ nyc@14.1.1
  ├─┬ istanbul-lib-instrument@3.3.0
  │ └── semver@6.3.0
  ├─┬ make-dir@2.1.0
  │ └── semver@5.7.1
  └─┬ test-exclude@5.2.3
    └─┬ read-pkg-up@4.0.0
      └─┬ read-pkg@3.0.0
        └─┬ normalize-package-data@2.5.0
          └── semver@5.5.1
```

```
connor.burton@LM-C02FV8NHMD6R datastar % npm ls word-wrap
datastar@4.0.3 /Users/connor.burton/dev/datastar
└─┬ eslint@8.29.0
  └─┬ optionator@0.9.1
    └── word-wrap@1.2.3
```

I ran the tests via `npm run test` and 3 tests are failing, however they also fail in `master` and seem to be related to needing a local Cassandra DB running at `127.0.0.1:9042` - I don't think this is indicative of any regression. I couldn't find any full instructions in the README for setting up a local Cassandra in the way the tests expect.

Overall the risk of regression is minimal, given the only runtime change is `joi-of-cql` and that had a full suite of tests of it's own that passed when on the most recent update.