### PR TITLE
fix: upgrade lodash to address prototype pollution vulnerability

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,7 +1,7 @@
 const
   { EventEmitter }            = require('events'),
   { PassThrough, Readable }   = require('stream'),
-  pick                        = require('lodash.pick'),
+  { pick }                    = require('lodash'),
   async                       = require('async'),
   clone                       = require('clone'),
   assign                      = require('object-assign'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "async": "^3.2.4",
         "clone": "^1.0.4",
         "joi-of-cql": "^2.0.4",
-        "lodash.pick": "^4.0.1",
+        "lodash": "^4.17.21",
         "object-assign": "^4.0.1",
         "priam": "^4.0.0",
         "tinythen": "^1.0.1",
@@ -39,7 +39,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "dependencies": {
@@ -48,7 +48,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/generator/-/generator-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/generator/-/generator-7.5.5.tgz",
       "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
       "dev": true,
       "dependencies": {
@@ -61,7 +61,7 @@
     },
     "node_modules/@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "dev": true,
       "dependencies": {
@@ -72,7 +72,7 @@
     },
     "node_modules/@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "dev": true,
       "dependencies": {
@@ -81,7 +81,7 @@
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "dependencies": {
@@ -90,7 +90,7 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/highlight/-/highlight-7.5.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
       "dev": true,
       "dependencies": {
@@ -101,13 +101,13 @@
     },
     "node_modules/@babel/highlight/node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "node_modules/@babel/parser": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/parser/-/parser-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/parser/-/parser-7.5.5.tgz",
       "integrity": "sha1-AvB3rIgX099Kgy71neZ1Zeccyks=",
       "dev": true,
       "bin": {
@@ -119,7 +119,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.4.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/template/-/template-7.4.4.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
       "dev": true,
       "dependencies": {
@@ -130,7 +130,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/traverse/-/traverse-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/traverse/-/traverse-7.5.5.tgz",
       "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
       "dev": true,
       "dependencies": {
@@ -147,7 +147,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/types/-/types-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/types/-/types-7.5.5.tgz",
       "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
       "dev": true,
       "dependencies": {
@@ -362,7 +362,7 @@
     },
     "node_modules/append-transform": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/append-transform/-/append-transform-1.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/append-transform/-/append-transform-1.0.0.tgz",
       "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
       "dev": true,
       "dependencies": {
@@ -374,7 +374,7 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/archy/-/archy-1.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
@@ -457,7 +457,7 @@
     },
     "node_modules/caching-transform": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/caching-transform/-/caching-transform-3.0.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/caching-transform/-/caching-transform-3.0.2.tgz",
       "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
       "dev": true,
       "dependencies": {
@@ -472,7 +472,7 @@
     },
     "node_modules/caching-transform/node_modules/hasha": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
       "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
       "dev": true,
       "dependencies": {
@@ -502,7 +502,7 @@
     },
     "node_modules/cassandra-driver": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cassandra-driver/-/cassandra-driver-4.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/cassandra-driver/-/cassandra-driver-4.1.0.tgz",
       "integrity": "sha1-4TSCKJAgWWJY1gAms/y9VXDcqwA=",
       "dependencies": {
         "long": "^2.2.0"
@@ -602,7 +602,7 @@
     },
     "node_modules/commondir": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -614,7 +614,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "dependencies": {
@@ -623,7 +623,7 @@
     },
     "node_modules/cp-file": {
       "version": "6.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cp-file/-/cp-file-6.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/cp-file/-/cp-file-6.2.0.tgz",
       "integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
       "dev": true,
       "dependencies": {
@@ -639,7 +639,7 @@
     },
     "node_modules/cp-file/node_modules/pify": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true,
       "engines": {
@@ -727,7 +727,7 @@
     },
     "node_modules/default-require-extensions": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "dependencies": {
@@ -760,13 +760,13 @@
     },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "dependencies": {
@@ -775,7 +775,7 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/es6-error/-/es6-error-4.1.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
       "dev": true
     },
@@ -1175,7 +1175,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true,
       "bin": {
@@ -1294,7 +1294,7 @@
     },
     "node_modules/find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
       "dev": true,
       "dependencies": {
@@ -1308,7 +1308,7 @@
     },
     "node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "dependencies": {
@@ -1369,7 +1369,7 @@
     },
     "node_modules/foreground-child": {
       "version": "1.5.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/foreground-child/-/foreground-child-1.5.6.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "dependencies": {
@@ -1379,7 +1379,7 @@
     },
     "node_modules/foreground-child/node_modules/cross-spawn": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "dependencies": {
@@ -1419,7 +1419,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "engines": {
@@ -1570,7 +1570,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -1709,7 +1709,7 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
       "dev": true,
       "engines": {
@@ -1718,7 +1718,7 @@
     },
     "node_modules/istanbul-lib-hook": {
       "version": "2.0.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
       "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
       "dev": true,
       "dependencies": {
@@ -1730,7 +1730,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "dev": true,
       "dependencies": {
@@ -1757,7 +1757,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
       "dev": true,
       "dependencies": {
@@ -1771,7 +1771,7 @@
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
       "version": "6.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-6.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
       "dev": true,
       "dependencies": {
@@ -1783,7 +1783,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
       "dev": true,
       "dependencies": {
@@ -1799,7 +1799,7 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -1882,7 +1882,7 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true,
       "bin": {
@@ -1894,7 +1894,7 @@
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
@@ -1938,7 +1938,7 @@
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "dependencies": {
@@ -1953,7 +1953,7 @@
     },
     "node_modules/load-json-file/node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
       "engines": {
@@ -1962,7 +1962,7 @@
     },
     "node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "dependencies": {
@@ -1986,7 +1986,7 @@
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
@@ -1995,11 +1995,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -2113,7 +2108,7 @@
     },
     "node_modules/make-dir": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/make-dir/-/make-dir-2.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "dependencies": {
@@ -2126,7 +2121,7 @@
     },
     "node_modules/make-dir/node_modules/pify": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true,
       "engines": {
@@ -2141,7 +2136,7 @@
     },
     "node_modules/merge-source-map": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/merge-source-map/-/merge-source-map-1.1.0.tgz",
       "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
       "dev": true,
       "dependencies": {
@@ -2150,7 +2145,7 @@
     },
     "node_modules/merge-source-map/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -2516,13 +2511,13 @@
     },
     "node_modules/nested-error-stacks": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
       "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "dependencies": {
@@ -2534,7 +2529,7 @@
     },
     "node_modules/normalize-package-data/node_modules/resolve": {
       "version": "1.12.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve/-/resolve-1.12.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
       "dev": true,
       "dependencies": {
@@ -2552,7 +2547,7 @@
     },
     "node_modules/nyc": {
       "version": "14.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nyc/-/nyc-14.1.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/nyc/-/nyc-14.1.1.tgz",
       "integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
       "dev": true,
       "dependencies": {
@@ -2591,7 +2586,7 @@
     },
     "node_modules/nyc/node_modules/uuid": {
       "version": "3.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
@@ -2641,7 +2636,7 @@
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "engines": {
@@ -2650,7 +2645,7 @@
     },
     "node_modules/p-limit": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/p-limit/-/p-limit-2.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
       "dev": true,
       "dependencies": {
@@ -2662,7 +2657,7 @@
     },
     "node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "dependencies": {
@@ -2674,7 +2669,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "engines": {
@@ -2683,7 +2678,7 @@
     },
     "node_modules/package-hash": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/package-hash/-/package-hash-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/package-hash/-/package-hash-3.0.0.tgz",
       "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
       "dev": true,
       "dependencies": {
@@ -2698,13 +2693,13 @@
     },
     "node_modules/package-hash/node_modules/graceful-fs": {
       "version": "4.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/graceful-fs/-/graceful-fs-4.2.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/graceful-fs/-/graceful-fs-4.2.1.tgz",
       "integrity": "sha1-HB8MNkiCyGj1v/ZRIUYygzahGx0=",
       "dev": true
     },
     "node_modules/package-hash/node_modules/hasha": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
       "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
       "dev": true,
       "dependencies": {
@@ -2728,7 +2723,7 @@
     },
     "node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "dependencies": {
@@ -2741,7 +2736,7 @@
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
       "engines": {
@@ -2774,7 +2769,7 @@
     },
     "node_modules/path-type": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-type/-/path-type-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "dev": true,
       "dependencies": {
@@ -2786,7 +2781,7 @@
     },
     "node_modules/path-type/node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
       "engines": {
@@ -2807,7 +2802,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "dev": true,
       "dependencies": {
@@ -2886,7 +2881,7 @@
     },
     "node_modules/q": {
       "version": "1.5.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/q/-/q-1.5.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "engines": {
         "node": ">=0.6.0",
@@ -2930,7 +2925,7 @@
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "dependencies": {
@@ -2944,7 +2939,7 @@
     },
     "node_modules/read-pkg-up": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
       "dev": true,
       "dependencies": {
@@ -2981,7 +2976,7 @@
     },
     "node_modules/release-zalgo": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/release-zalgo/-/release-zalgo-1.0.0.tgz",
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "dependencies": {
@@ -2993,7 +2988,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "engines": {
@@ -3002,7 +2997,7 @@
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
@@ -3023,7 +3018,7 @@
     },
     "node_modules/retry": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/retry/-/retry-0.6.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/retry/-/retry-0.6.1.tgz",
       "integrity": "sha1-/ckO7ZQ/3hG4k1VLjMY9DombqRg=",
       "engines": {
         "node": "*"
@@ -3107,7 +3102,7 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -3178,7 +3173,7 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "dependencies": {
@@ -3188,13 +3183,13 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "dependencies": {
@@ -3204,7 +3199,7 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
@@ -3278,7 +3273,7 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true,
       "engines": {
@@ -3311,7 +3306,7 @@
     },
     "node_modules/test-exclude": {
       "version": "5.2.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/test-exclude/-/test-exclude-5.2.3.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
       "dev": true,
       "dependencies": {
@@ -3479,7 +3474,7 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "dependencies": {
@@ -3538,7 +3533,7 @@
     },
     "node_modules/which-module": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -3559,7 +3554,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "dependencies": {
@@ -3573,7 +3568,7 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
       "dev": true,
       "dependencies": {
@@ -3593,7 +3588,7 @@
     },
     "node_modules/write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
       "dev": true,
       "dependencies": {
@@ -3616,7 +3611,7 @@
     },
     "node_modules/yargs": {
       "version": "13.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yargs/-/yargs-13.3.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
       "dev": true,
       "dependencies": {
@@ -3683,7 +3678,7 @@
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
       "dev": true,
       "dependencies": {
@@ -3711,7 +3706,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "requires": {
@@ -3720,7 +3715,7 @@
     },
     "@babel/generator": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/generator/-/generator-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/generator/-/generator-7.5.5.tgz",
       "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
       "dev": true,
       "requires": {
@@ -3733,7 +3728,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "dev": true,
       "requires": {
@@ -3744,7 +3739,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "dev": true,
       "requires": {
@@ -3753,7 +3748,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "requires": {
@@ -3762,7 +3757,7 @@
     },
     "@babel/highlight": {
       "version": "7.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/highlight/-/highlight-7.5.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
       "dev": true,
       "requires": {
@@ -3773,7 +3768,7 @@
       "dependencies": {
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/js-tokens/-/js-tokens-4.0.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
           "dev": true
         }
@@ -3781,13 +3776,13 @@
     },
     "@babel/parser": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/parser/-/parser-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/parser/-/parser-7.5.5.tgz",
       "integrity": "sha1-AvB3rIgX099Kgy71neZ1Zeccyks=",
       "dev": true
     },
     "@babel/template": {
       "version": "7.4.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/template/-/template-7.4.4.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
       "dev": true,
       "requires": {
@@ -3798,7 +3793,7 @@
     },
     "@babel/traverse": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/traverse/-/traverse-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/traverse/-/traverse-7.5.5.tgz",
       "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
       "dev": true,
       "requires": {
@@ -3815,7 +3810,7 @@
     },
     "@babel/types": {
       "version": "7.5.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/@babel/types/-/types-7.5.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@babel/types/-/types-7.5.5.tgz",
       "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
       "dev": true,
       "requires": {
@@ -3974,7 +3969,7 @@
     },
     "append-transform": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/append-transform/-/append-transform-1.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/append-transform/-/append-transform-1.0.0.tgz",
       "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
       "dev": true,
       "requires": {
@@ -3983,7 +3978,7 @@
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/archy/-/archy-1.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
@@ -4060,7 +4055,7 @@
     },
     "caching-transform": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/caching-transform/-/caching-transform-3.0.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/caching-transform/-/caching-transform-3.0.2.tgz",
       "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
       "dev": true,
       "requires": {
@@ -4072,7 +4067,7 @@
       "dependencies": {
         "hasha": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
           "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
           "dev": true,
           "requires": {
@@ -4095,7 +4090,7 @@
     },
     "cassandra-driver": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cassandra-driver/-/cassandra-driver-4.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/cassandra-driver/-/cassandra-driver-4.1.0.tgz",
       "integrity": "sha1-4TSCKJAgWWJY1gAms/y9VXDcqwA=",
       "requires": {
         "long": "^2.2.0"
@@ -4174,7 +4169,7 @@
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -4186,7 +4181,7 @@
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "requires": {
@@ -4195,7 +4190,7 @@
     },
     "cp-file": {
       "version": "6.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cp-file/-/cp-file-6.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/cp-file/-/cp-file-6.2.0.tgz",
       "integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
       "dev": true,
       "requires": {
@@ -4208,7 +4203,7 @@
       "dependencies": {
         "pify": {
           "version": "4.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
           "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         }
@@ -4276,7 +4271,7 @@
     },
     "default-require-extensions": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
@@ -4300,13 +4295,13 @@
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -4315,7 +4310,7 @@
     },
     "es6-error": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/es6-error/-/es6-error-4.1.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
       "dev": true
     },
@@ -4596,7 +4591,7 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
@@ -4687,7 +4682,7 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
       "dev": true,
       "requires": {
@@ -4698,7 +4693,7 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "requires": {
@@ -4746,7 +4741,7 @@
     },
     "foreground-child": {
       "version": "1.5.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/foreground-child/-/foreground-child-1.5.6.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
@@ -4756,7 +4751,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
@@ -4790,7 +4785,7 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
@@ -4904,7 +4899,7 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -5004,13 +4999,13 @@
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
       "dev": true
     },
     "istanbul-lib-hook": {
       "version": "2.0.7",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
       "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
       "dev": true,
       "requires": {
@@ -5019,7 +5014,7 @@
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "dev": true,
       "requires": {
@@ -5042,7 +5037,7 @@
     },
     "istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
       "dev": true,
       "requires": {
@@ -5053,7 +5048,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -5064,7 +5059,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
       "dev": true,
       "requires": {
@@ -5077,7 +5072,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -5142,13 +5137,13 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
@@ -5188,7 +5183,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -5200,7 +5195,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -5208,7 +5203,7 @@
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "requires": {
@@ -5229,7 +5224,7 @@
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
@@ -5238,11 +5233,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -5328,7 +5318,7 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/make-dir/-/make-dir-2.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "requires": {
@@ -5338,7 +5328,7 @@
       "dependencies": {
         "pify": {
           "version": "4.0.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-4.0.1.tgz",
           "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         }
@@ -5352,7 +5342,7 @@
     },
     "merge-source-map": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/merge-source-map/-/merge-source-map-1.1.0.tgz",
       "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
       "dev": true,
       "requires": {
@@ -5361,7 +5351,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -5627,13 +5617,13 @@
     },
     "nested-error-stacks": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
       "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -5645,7 +5635,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.12.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve/-/resolve-1.12.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/resolve/-/resolve-1.12.0.tgz",
           "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
           "dev": true,
           "requires": {
@@ -5662,7 +5652,7 @@
     },
     "nyc": {
       "version": "14.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nyc/-/nyc-14.1.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/nyc/-/nyc-14.1.1.tgz",
       "integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
       "dev": true,
       "requires": {
@@ -5695,7 +5685,7 @@
       "dependencies": {
         "uuid": {
           "version": "3.3.2",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
           "dev": true
         }
@@ -5737,13 +5727,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "p-limit": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/p-limit/-/p-limit-2.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
       "dev": true,
       "requires": {
@@ -5752,7 +5742,7 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "requires": {
@@ -5761,13 +5751,13 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "package-hash": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/package-hash/-/package-hash-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/package-hash/-/package-hash-3.0.0.tgz",
       "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
       "dev": true,
       "requires": {
@@ -5779,13 +5769,13 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.2.1",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/graceful-fs/-/graceful-fs-4.2.1.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/graceful-fs/-/graceful-fs-4.2.1.tgz",
           "integrity": "sha1-HB8MNkiCyGj1v/ZRIUYygzahGx0=",
           "dev": true
         },
         "hasha": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/hasha/-/hasha-3.0.0.tgz",
           "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
           "dev": true,
           "requires": {
@@ -5805,7 +5795,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -5815,7 +5805,7 @@
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
@@ -5839,7 +5829,7 @@
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-type/-/path-type-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "dev": true,
       "requires": {
@@ -5848,7 +5838,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -5862,7 +5852,7 @@
     },
     "pkg-dir": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "dev": true,
       "requires": {
@@ -5929,7 +5919,7 @@
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/q/-/q-1.5.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "queue-microtask": {
@@ -5955,7 +5945,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
@@ -5966,7 +5956,7 @@
     },
     "read-pkg-up": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
       "dev": true,
       "requires": {
@@ -5991,7 +5981,7 @@
     },
     "release-zalgo": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/release-zalgo/-/release-zalgo-1.0.0.tgz",
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
@@ -6000,13 +5990,13 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
@@ -6024,7 +6014,7 @@
     },
     "retry": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/retry/-/retry-0.6.1.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/retry/-/retry-0.6.1.tgz",
       "integrity": "sha1-/ckO7ZQ/3hG4k1VLjMY9DombqRg="
     },
     "reusify": {
@@ -6080,7 +6070,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -6139,7 +6129,7 @@
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
@@ -6149,13 +6139,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
@@ -6165,7 +6155,7 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
@@ -6228,7 +6218,7 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
@@ -6249,7 +6239,7 @@
     },
     "test-exclude": {
       "version": "5.2.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/test-exclude/-/test-exclude-5.2.3.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
       "dev": true,
       "requires": {
@@ -6387,7 +6377,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -6443,7 +6433,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -6461,7 +6451,7 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
@@ -6472,7 +6462,7 @@
       "dependencies": {
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -6491,7 +6481,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
       "dev": true,
       "requires": {
@@ -6514,7 +6504,7 @@
     },
     "yargs": {
       "version": "13.3.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yargs/-/yargs-13.3.0.tgz",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
       "dev": true,
       "requires": {
@@ -6532,7 +6522,7 @@
       "dependencies": {
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "async": "^3.2.4",
     "clone": "^1.0.4",
     "joi-of-cql": "^2.0.4",
-    "lodash.pick": "^4.0.1",
+    "lodash": "^4.17.21",
     "object-assign": "^4.0.1",
     "priam": "^4.0.0",
     "tinythen": "^1.0.1",


### PR DESCRIPTION
## Changes Made
- Replaced `lodash.pick` 4.4.0 with main `lodash` 4.17.21
- Updated require statement in `lib/model.js` to use `lodash.pick` from the main package
- Updated package.json and package-lock.json accordingly

## Security Issue
- `lodash.pick` versions 4.0.0-4.4.0 are vulnerable to prototype pollution
- The main `lodash` package version 4.17.21 includes security fixes for this issue

## Testing
- All unit tests pass 