### PR TITLE
chore: upgrade to priam 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ language: node_js
 matrix:
   fast_finish: true
   include:
-    - node_js: "13"
-    - node_js: "12.3"
-    - node_js: "10.17"
+    - node_js: "24"
+    - node_js: "22"
+    - node_js: "20"
+    - node_js: "18"
 services:
   - cassandra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.0
+
+- (breaking) support node versions 10 through 17 is dropped; minimum node version is now 18.0.x.
+
 ## 4.0.4
 
 - (fix) address vulnerable packagse

--- a/lib/pick.js
+++ b/lib/pick.js
@@ -7,7 +7,7 @@ module.exports = function pick(obj, keys) {
   if (obj != null) {
     for (const key of keys) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {
-       result[key] = obj[key];
+        result[key] = obj[key];
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "clone": "^1.0.4",
         "joi-of-cql": "^2.0.4",
         "object-assign": "^4.0.1",
-        "priam": "^4.0.0",
+        "priam": "^5.0.0",
         "tinythen": "^1.0.1",
         "to-camel-case": "^1.0.0",
         "to-snake-case": "^1.0.0",
@@ -23,7 +23,7 @@
       "devDependencies": {
         "assume": "^2.1.0",
         "assume-sinon": "^1.0.0",
-        "cassandra-driver": "^4.1.0",
+        "cassandra-driver": "^4.8.0",
         "eslint": "^8.29.0",
         "eslint-config-godaddy": "^7.0.0",
         "lodash.clonedeep": "^4.5.0",
@@ -33,7 +33,7 @@
         "sinon": "^1.17.2"
       },
       "engines": {
-        "node": "^10.17.0 || >=12.3.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -81,6 +81,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -706,6 +707,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -856,6 +858,7 @@
       "integrity": "sha512-Pv24RxCZMXe5ZXXZqMqEWMVtPByjzxN4VQ+Yh0nRiChxUlR8vrSEQLqG11xVuzU14MEv9c1xOfREhPcQmH2+dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-eql": "^3.0.1",
         "fn.name": "^1.0.1",
@@ -971,6 +974,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -1468,6 +1472,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3634,12 +3639,12 @@
       }
     },
     "node_modules/priam": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/priam/-/priam-4.1.0.tgz",
-      "integrity": "sha512-NZhnZiCJh9TjcZdW47zdWmbJvXBR8C3Hh+qLmS3oMaHMiRl/oAEhWOJFGj1+qzjK28Ufu3/LvICBDq2VtoCi7g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/priam/-/priam-5.0.0.tgz",
+      "integrity": "sha512-suTti5ylPKyNVeoD4LqvGUTdXiaZ9io4bjg6p3HuxPYJYYnB2YKToqzh0gZlslRUTAeQVNsoXp18+029WxPytQ==",
       "license": "MIT",
       "dependencies": {
-        "cassandra-driver": "^4.1.0",
+        "cassandra-driver": "^4.8.0",
         "isstream": "^0.1.2",
         "lodash": "^4.17.21",
         "q": "^1.4.1",
@@ -3647,7 +3652,7 @@
         "uuid": "^2.0.1"
       },
       "engines": {
-        "node": "^10.17.0 || >=12.3.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/process-on-spawn": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clone": "^1.0.4",
     "joi-of-cql": "^2.0.4",
     "object-assign": "^4.0.1",
-    "priam": "^4.0.0",
+    "priam": "^5.0.0",
     "tinythen": "^1.0.1",
     "to-camel-case": "^1.0.0",
     "to-snake-case": "^1.0.0",
@@ -23,7 +23,7 @@
   "devDependencies": {
     "assume": "^2.1.0",
     "assume-sinon": "^1.0.0",
-    "cassandra-driver": "^4.1.0",
+    "cassandra-driver": "^4.8.0",
     "eslint": "^8.29.0",
     "eslint-config-godaddy": "^7.0.0",
     "lodash.clonedeep": "^4.5.0",
@@ -52,7 +52,7 @@
     "data modeling"
   ],
   "engines": {
-    "node": "^10.17.0 || >=12.3.0"
+    "node": ">=18.0.0"
   },
   "author": "GoDaddy Engineers",
   "license": "MIT"


### PR DESCRIPTION
Also support modern node versions. Please see https://github.com/godaddy/node-priam/pull/91 for details.